### PR TITLE
fixing tweepy exception invalid pagnination method

### DIFF
--- a/04/test_usertweets.py
+++ b/04/test_usertweets.py
@@ -26,7 +26,7 @@ def read_csv(fname):
 class TestUserTweets(unittest.TestCase):
     def setUp(self):
         super().setUp()
-        with patch('tweepy.API.user_timeline') as mock_timeline:
+        with patch('tweepy.API') as mock_timeline:
             mock_timeline.return_value = TWEETS
             self.user = UserTweets(HANDLE, max_id=MAX_ID)
 


### PR DESCRIPTION

Tweep.error('Invalid Pagnation Mode') caused inside TestUserTweets after patching only tweepy.API.user_timeline when you try to use the new Cursor method:

`cursor = tweepy.Cursor(api.user_timeline)`

Where api is the authorized api returned from `tweepy.API()`